### PR TITLE
Dependency telemetry scoping

### DIFF
--- a/Example.Instrumented.Library/Example.Instrumented.Library.csproj
+++ b/Example.Instrumented.Library/Example.Instrumented.Library.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="system.diagnostics.diagnosticsource" Version="4.4.1" />
+    <PackageReference Include="system.diagnostics.diagnosticsource" Version="4.4.0" />
     <PackageReference Include="system.valuetuple" Version="4.3.1" />
   </ItemGroup>
 

--- a/Example.Instrumented.Library/Example.Instrumented.Library.csproj
+++ b/Example.Instrumented.Library/Example.Instrumented.Library.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="system.diagnostics.diagnosticsource" Version="4.4.1" />
     <PackageReference Include="system.valuetuple" Version="4.3.1" />
   </ItemGroup>
 

--- a/Pocket.Logger/Core/LogEvents.cs
+++ b/Pocket.Logger/Core/LogEvents.cs
@@ -29,7 +29,7 @@ namespace Pocket
         public static IDisposable Subscribe(
             Action<(
                     byte LogLevel,
-                    DateTimeOffset Timestamp,
+                    DateTime TimestampUtc,
                     Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                     Exception Exception,
                     string OperationName,

--- a/Pocket.Logger/Core/LogEvents.cs
+++ b/Pocket.Logger/Core/LogEvents.cs
@@ -28,7 +28,7 @@ namespace Pocket
 
         public static IDisposable Subscribe(
             Action<(
-                    int LogLevel,
+                    byte LogLevel,
                     DateTimeOffset Timestamp,
                     Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                     Exception Exception,

--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -290,13 +290,11 @@ namespace Pocket
         public static OperationLogger OnEnterAndExit(
             this Logger logger,
             [CallerMemberName] string name = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null)
         {
             return new OperationLogger(
                 name,
                 logger.Category,
-                id,
                 exitArgs,
                 true);
         }
@@ -304,35 +302,29 @@ namespace Pocket
         public static OperationLogger OnExit(
             this Logger logger,
             [CallerMemberName] string name = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null) =>
             new OperationLogger(
                 name,
                 logger.Category,
-                id,
                 exitArgs);
 
         public static ConfirmationLogger ConfirmOnExit(
             this Logger logger,
             [CallerMemberName] string name = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null) =>
             new ConfirmationLogger(
                 name,
                 logger.Category,
-                id,
                 exitArgs);
 
         public static ConfirmationLogger OnEnterAndConfirmOnExit(
             this Logger logger,
             [CallerMemberName] string name = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null)
         {
             return new ConfirmationLogger(
                 name,
                 logger.Category,
-                id,
                 exitArgs,
                 true);
         }
@@ -453,10 +445,9 @@ namespace Pocket
         public ConfirmationLogger(
             string operationName = null,
             string category = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null,
             bool logOnStart = false) :
-            base(operationName, category, id, exitArgs, logOnStart)
+            base(operationName, category, exitArgs, logOnStart)
         {
         }
 
@@ -500,15 +491,12 @@ namespace Pocket
         public OperationLogger(
             string operationName = null,
             string category = null,
-            string id = null,
             Func<(string name, object value)[]> exitArgs = null,
             bool logOnStart = false) : base(category)
         {
             this.exitArgs = exitArgs;
 
             activity = new Activity(operationName).Start();
-
-            Id = id ?? activity.Id;
 
             IsStarting = true;
 
@@ -528,7 +516,7 @@ namespace Pocket
             }
         }
 
-        public string Id { get; }
+        public string Id => activity.Id;
 
         public string Name => activity.OperationName;
 

--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -19,7 +18,7 @@ namespace Pocket
         public static event Action<Action<(string Name, object Value)>> Enrich;
 
         public static event Action<(
-            int LogLevel,
+            byte LogLevel,
             DateTimeOffset Timestamp,
             Func<(string Message, (string Name, object Value)[] properties)> Evaluate,
             Exception Exception,
@@ -36,7 +35,7 @@ namespace Pocket
             Enrich?.Invoke(entry.AddProperty);
 
             Posted?.Invoke(
-                ((int) entry.LogLevel,
+                ((byte) entry.LogLevel,
                 entry.Timestamp,
                 entry.Evaluate,
                 entry.Exception,
@@ -98,7 +97,7 @@ namespace Pocket
     {
         public static string ToLogString(
             this (
-                int LogLevel,
+                byte LogLevel,
                 DateTimeOffset Timestamp,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
@@ -120,7 +119,7 @@ namespace Pocket
                                e.Operation.Duration);
 
             return
-                $"{e.Timestamp:o} {e.Operation.Id.IfNotEmpty()}{e.Category.IfNotEmpty()}{e.OperationName.IfNotEmpty()} {logLevelString}  {evaluated.Message} {e.Exception}";
+                $"{e.Timestamp:o} {e.Operation.Id.IfNotEmpty()}{e.Category.IfNotEmpty()}{e.OperationName.IfNotEmpty()} {logLevelString} {evaluated.Message} {e.Exception}";
         }
 
         
@@ -203,7 +202,7 @@ namespace Pocket
         }
     }
 
-    internal enum LogLevel
+    internal enum LogLevel : byte
     {
         Telemetry,
         Trace,

--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -19,7 +19,7 @@ namespace Pocket
 
         public static event Action<(
             byte LogLevel,
-            DateTimeOffset Timestamp,
+            DateTime TimestampUtc,
             Func<(string Message, (string Name, object Value)[] properties)> Evaluate,
             Exception Exception,
             string OperationName,
@@ -36,7 +36,7 @@ namespace Pocket
 
             Posted?.Invoke(
                 ((byte) entry.LogLevel,
-                entry.Timestamp,
+                entry.TimestampUtc,
                 entry.Evaluate,
                 entry.Exception,
                 entry.OperationName,
@@ -98,7 +98,7 @@ namespace Pocket
         public static string ToLogString(
             this (
                 byte LogLevel,
-                DateTimeOffset Timestamp,
+                DateTime TimestampUtc,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
                 string OperationName,
@@ -119,7 +119,7 @@ namespace Pocket
                                e.Operation.Duration);
 
             return
-                $"{e.Timestamp:o} {e.Operation.Id.IfNotEmpty()}{e.Category.IfNotEmpty()}{e.OperationName.IfNotEmpty()} {logLevelString} {evaluated.Message} {e.Exception}";
+                $"{e.TimestampUtc:o} {e.Operation.Id.IfNotEmpty()}{e.Category.IfNotEmpty()}{e.OperationName.IfNotEmpty()} {logLevelString} {evaluated.Message} {e.Exception}";
         }
 
         
@@ -442,7 +442,7 @@ namespace Pocket
 
         public OperationLogger Operation { get; }
 
-        public DateTimeOffset Timestamp { get; } = DateTimeOffset.Now;
+        public DateTime TimestampUtc { get; } = DateTime.UtcNow;
 
         public LogLevel LogLevel { get; }
 

--- a/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
+++ b/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
@@ -14,13 +14,13 @@ namespace Pocket.For.ApplicationInsights
         {
             return LogEvents.Subscribe(e =>
             {
-                if (e.Operation.IsEnd)
-                {
-                    telemetryClient.TrackDependency(e.ToDependencyTelemetry());
-                }
-                else if (e.LogLevel == (int) LogLevel.Telemetry)
+                if (e.LogLevel == (byte) LogLevel.Telemetry)
                 {
                     telemetryClient.TrackEvent(e.ToEventTelemetry());
+                }
+                else if (e.Operation.IsEnd)
+                {
+                    telemetryClient.TrackDependency(e.ToDependencyTelemetry());
                 }
                 else if (e.Exception != null)
                 {
@@ -34,7 +34,7 @@ namespace Pocket.For.ApplicationInsights
         }
 
         internal static DependencyTelemetry ToDependencyTelemetry(
-            this (int LogLevel,
+            this (byte LogLevel,
                 DateTimeOffset Timestamp,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
@@ -78,7 +78,7 @@ namespace Pocket.For.ApplicationInsights
         }
 
         internal static EventTelemetry ToEventTelemetry(
-            this ( int LogLevel,
+            this (byte LogLevel,
                 DateTimeOffset Timestamp,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
@@ -117,7 +117,7 @@ namespace Pocket.For.ApplicationInsights
         }
 
         internal static ExceptionTelemetry ToExceptionTelemetry(
-            this ( int LogLevel,
+            this (byte LogLevel,
                 DateTimeOffset Timestamp,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
@@ -138,7 +138,7 @@ namespace Pocket.For.ApplicationInsights
         }
 
         internal static TraceTelemetry ToTraceTelemetry(
-            this ( int LogLevel,
+            this (byte LogLevel,
                 DateTimeOffset Timestamp,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,

--- a/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
+++ b/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
@@ -35,7 +35,7 @@ namespace Pocket.For.ApplicationInsights
 
         internal static DependencyTelemetry ToDependencyTelemetry(
             this (byte LogLevel,
-                DateTimeOffset Timestamp,
+                DateTime TimestampUtc,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
                 string OperationName,
@@ -79,7 +79,7 @@ namespace Pocket.For.ApplicationInsights
 
         internal static EventTelemetry ToEventTelemetry(
             this (byte LogLevel,
-                DateTimeOffset Timestamp,
+                DateTime TimestampUtc,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
                 string OperationName,
@@ -118,7 +118,7 @@ namespace Pocket.For.ApplicationInsights
 
         internal static ExceptionTelemetry ToExceptionTelemetry(
             this (byte LogLevel,
-                DateTimeOffset Timestamp,
+                DateTime TimestampUtc,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
                 string OperationName,
@@ -139,7 +139,7 @@ namespace Pocket.For.ApplicationInsights
 
         internal static TraceTelemetry ToTraceTelemetry(
             this (byte LogLevel,
-                DateTimeOffset Timestamp,
+                DateTime TimestampUtc,
                 Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
                 Exception Exception,
                 string OperationName,

--- a/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
+++ b/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
@@ -65,7 +65,7 @@ namespace Pocket.For.ApplicationInsights.Tests
                 "my-operation",
                 exitArgs: () => new (string, object)[] { ("RequestUri", new Uri("http://example.com") ) }))
             {
-                await Task.Delay(500);
+                await Task.Delay(200);
                 operation.Succeed("{ResultCode}", 200);
             }
 
@@ -73,7 +73,7 @@ namespace Pocket.For.ApplicationInsights.Tests
             var actual = (DependencyTelemetry) telemetrySent[1];
 
             actual.Data.Should().Be(expected.Data);
-            actual.Duration.Should().BeCloseTo(expected.Duration, precision: 50);
+            actual.Duration.Should().BeGreaterOrEqualTo(200.Milliseconds());
             actual.Name.Should().Be(expected.Name);
             actual.Properties.ShouldBeEquivalentTo(expected.Properties);
             actual.ResultCode.Should().Be(expected.ResultCode);

--- a/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
+++ b/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using FluentAssertions;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
@@ -42,7 +43,7 @@ namespace Pocket.For.ApplicationInsights.Tests
         public void Dispose() => disposables.Dispose();
 
         [Fact]
-        public void Log_events_can_be_used_to_send_dependency_tracking_on_operation_complete()
+        public async Task Log_events_can_be_used_to_send_dependency_tracking_on_operation_complete()
         {
             var id = Guid.NewGuid().ToString();
             client.TrackDependency(new DependencyTelemetry
@@ -67,7 +68,7 @@ namespace Pocket.For.ApplicationInsights.Tests
                 id,
                 exitArgs: () => new (string, object)[] { ("RequestUri", new Uri("http://example.com") ) }))
             {
-                Thread.Sleep(500);
+                await Task.Delay(500);
                 operation.Succeed("{ResultCode}", 200);
             }
 
@@ -75,7 +76,7 @@ namespace Pocket.For.ApplicationInsights.Tests
             var actual = (DependencyTelemetry) telemetrySent[1];
 
             actual.Data.Should().Be(expected.Data);
-            actual.Duration.Should().BeCloseTo(expected.Duration);
+            actual.Duration.Should().BeCloseTo(expected.Duration, precision: 50);
             actual.Id.Should().Be(expected.Id);
             actual.Name.Should().Be(expected.Name);
             actual.Properties.ShouldBeEquivalentTo(expected.Properties);

--- a/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
+++ b/Pocket.Logger/For.ApplicationInsights/Tests/PocketLoggerForApplicationInsightsTests.cs
@@ -45,12 +45,10 @@ namespace Pocket.For.ApplicationInsights.Tests
         [Fact]
         public async Task Log_events_can_be_used_to_send_dependency_tracking_on_operation_complete()
         {
-            var id = Guid.NewGuid().ToString();
             client.TrackDependency(new DependencyTelemetry
             {
                 Data = "http://example.com/",
                 Duration = 500.Milliseconds(),
-                Id = id,
                 Success = true,
                 Timestamp = DateTimeOffset.UtcNow,
                 Name = "my-operation",
@@ -65,7 +63,6 @@ namespace Pocket.For.ApplicationInsights.Tests
             using (client.SubscribeToPocketLogger())
             using (var operation = Log.ConfirmOnExit(
                 "my-operation",
-                id,
                 exitArgs: () => new (string, object)[] { ("RequestUri", new Uri("http://example.com") ) }))
             {
                 await Task.Delay(500);
@@ -77,7 +74,6 @@ namespace Pocket.For.ApplicationInsights.Tests
 
             actual.Data.Should().Be(expected.Data);
             actual.Duration.Should().BeCloseTo(expected.Duration, precision: 50);
-            actual.Id.Should().Be(expected.Id);
             actual.Name.Should().Be(expected.Name);
             actual.Properties.ShouldBeEquivalentTo(expected.Properties);
             actual.ResultCode.Should().Be(expected.ResultCode);

--- a/Pocket.Logger/Pocket.Logger.csproj
+++ b/Pocket.Logger/Pocket.Logger.csproj
@@ -10,13 +10,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="fluentassertions" Version="4.18.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
     <PackageReference Include="pocket.typediscovery" Version="0.3.11" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/Pocket.Logger/Pocket.Logger.csproj
+++ b/Pocket.Logger/Pocket.Logger.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
     <PackageReference Include="pocket.typediscovery" Version="0.3.11" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/Pocket.Logger/PocketLogger.For.ApplicationInsights.nuspec
+++ b/Pocket.Logger/PocketLogger.For.ApplicationInsights.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.For.ApplicationInsights</id>
     <title>PocketLogger.For.ApplicationInsights</title>
-    <version>0.1.3</version>
+    <version>0.2.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -15,7 +15,7 @@
     <dependencies>
       <dependency id="PocketLogger" version="[0.1.0,0.2)" />
       <dependency id="PocketLogger.Subscribe" version="[0.1.0,0.2)" />
-      <dependency id="Microsoft.ApplicationInsights" version="[2.3.0,)" />
+      <dependency id="Microsoft.ApplicationInsights" version="[2.4.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger</id>
     <title>PocketLogger</title>
-    <version>0.1.5</version>
+    <version>0.2.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -19,6 +19,7 @@ An embeddable logging and telemetry library for concise, multi-purpose instrumen
     <developmentDependency>true</developmentDependency>
     <dependencies>
       <dependency id="System.ValueTuple" version="[4.3.1,)" />
+      <dependency id="System.Diagnostics.DiagnosticSource" version="[4.4.1,)" />
     </dependencies>
   </metadata>
   <files>

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -19,7 +19,7 @@ An embeddable logging and telemetry library for concise, multi-purpose instrumen
     <developmentDependency>true</developmentDependency>
     <dependencies>
       <dependency id="System.ValueTuple" version="[4.3.1,)" />
-      <dependency id="System.Diagnostics.DiagnosticSource" version="[4.4.1,)" />
+      <dependency id="System.Diagnostics.DiagnosticSource" version="[4.4.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -186,7 +186,7 @@ namespace Pocket.Tests
             using (var operation = Log.ConfirmOnExit())
             {
                 operation.Succeed("success!");
-                await Task.Delay(50);
+                await Task.Delay(100);
                 operation.Info("hello");
             }
 
@@ -202,7 +202,7 @@ namespace Pocket.Tests
                 .Value;
 
             infoEvent.Should()
-                     .BeCloseTo(successEvent + 50.Milliseconds());
+                     .BeCloseTo(successEvent + 100.Milliseconds(), precision: 50);
         }
 
         [Fact]

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -251,14 +251,12 @@ namespace Pocket.Tests
         [Fact]
         public void Child_operations_have_ids_derived_from_their_parent_by_default()
         {
-            using (var parent = Log.ConfirmOnExit(id: "the-parent"))
+            using (var parent = Log.ConfirmOnExit())
             using (var child = parent.ConfirmOnExit())
-            using (var grandchild1 = child.ConfirmOnExit())
-            using (var grandchild2 = child.ConfirmOnExit())
+            using (var grandchild = child.ConfirmOnExit())
             {
-                child.Id.Should().Be("the-parent.1");
-                grandchild1.Id.Should().Be("the-parent.1.1");
-                grandchild2.Id.Should().Be("the-parent.1.2");
+                child.Id.Should().Contain(parent.Id);
+                grandchild.Id.Should().Contain(parent.Id);
             }
         }
 

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -266,7 +266,7 @@ namespace Pocket.Tests
             var log = new LogEntryList();
 
             using (Subscribe(log.Add))
-            using (var parent = Log.OnEnterAndConfirmOnExit(id: "the-parent"))
+            using (var parent = Log.OnEnterAndConfirmOnExit())
             {
                 for (var index = 0; index < 3; index++)
                 {

--- a/Pocket.Logger/Tests/LogEntryList.cs
+++ b/Pocket.Logger/Tests/LogEntryList.cs
@@ -5,7 +5,7 @@ namespace Pocket.Tests
 {
     public class LogEntryList : List<(
         byte LogLevel,
-        DateTimeOffset Timestamp,
+        DateTime TimestampUtc,
         Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
         Exception Exception,
         string OperationName,

--- a/Pocket.Logger/Tests/LogEntryList.cs
+++ b/Pocket.Logger/Tests/LogEntryList.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Pocket.Tests
 {
     public class LogEntryList : List<(
-        int LogLevel,
+        byte LogLevel,
         DateTimeOffset Timestamp,
         Func<(string Message, (string Name, object Value)[] Properties)> Evaluate,
         Exception Exception,

--- a/Pocket.Logger/Tests/OperationLoggerTests.cs
+++ b/Pocket.Logger/Tests/OperationLoggerTests.cs
@@ -125,28 +125,12 @@ namespace Pocket.Tests
         }
 
         [Fact]
-        public void Log_entries_within_an_operation_share_an_id_when_specified()
-        {
-            var log = new LogEntryList();
-            var operationId = "the-operation-id";
-
-            using (Subscribe(log.Add))
-            using (var operation = Log.OnEnterAndExit(id: operationId))
-            {
-                operation.Info("hello");
-            }
-
-            log.Select(e => e.Operation.Id).Should().OnlyContain(id => id == operationId);
-        }
-
-        [Fact]
         public void Log_entries_within_an_operation_share_an_id_when_not_specified()
         {
             var log = new LogEntryList();
-            var operationId = Guid.NewGuid().ToString();
 
             using (Subscribe(log.Add))
-            using (var operation = Log.OnEnterAndExit(id: operationId))
+            using (var operation = Log.OnEnterAndExit())
             {
                 operation.Info("hello");
             }
@@ -158,11 +142,13 @@ namespace Pocket.Tests
         public void Log_entries_within_an_operation_contain_their_id_in_string_output()
         {
             var log = new LogEntryList();
-            var operationId = Guid.NewGuid().ToString();
+            string operationId;
 
             using (Subscribe(log.Add))
-            using (var operation = Log.OnEnterAndExit(id: operationId))
+            using (var operation = Log.OnEnterAndExit())
             {
+                operationId = operation.Id;
+
                 operation.Info("hello");
             }
 


### PR DESCRIPTION
This change makes OperationLogger manage System.Diagnostics.Activity.Current, in order to then tie in correlation behaviors to Application Insights.