### PR TITLE
make enriching work across assemblies

### DIFF
--- a/Example.Instrumented.Library/Example.Instrumented.Library.csproj
+++ b/Example.Instrumented.Library/Example.Instrumented.Library.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Pocket.Logger/Pocket.Disposable.nuspec
+++ b/Pocket.Logger/Pocket.Disposable.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Pocket.Disposable</id>
     <title>Pocket.Disposable</title>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/PocketLogger.Subscribe.nuspec
+++ b/Pocket.Logger/PocketLogger.Subscribe.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.Subscribe</id>
     <title>PocketLogger.Subscribe</title>
-    <version>0.5.2</version>
+    <version>0.6.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger</id>
     <title>PocketLogger</title>
-    <version>0.2.13</version>
+    <version>0.3.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>


### PR DESCRIPTION
This fixes a bug where PocketLogger does not enrich log entries emitted from assemblies other the one where `Logger.Enrich` was called. `Logger.Enrich` has been removed and replaced with an optional parameter passed to `LogEvents.Subscribe`. The enricher is thus disposed along with the subscription, and applies to the same target assemblies as the subscription.