### PR TITLE
Make operationName a required parameter when constructing OperationLogger and ConfirmationLogger instances.

### DIFF
--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -420,7 +420,7 @@ internal class LogEntry
 internal class ConfirmationLogger : OperationLogger
 {
     public ConfirmationLogger(
-        string operationName = null,
+        string operationName,
         string category = null,
         string message = null,
         Func<(string name, object value)[]> exitArgs = null,
@@ -471,7 +471,7 @@ internal class OperationLogger : Logger, IDisposable
     private readonly Activity activity;
 
     public OperationLogger(
-        string operationName = null,
+        string operationName,
         string category = null,
         string message = null,
         Func<(string name, object value)[]> exitArgs = null,

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger</id>
     <title>PocketLogger</title>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -299,7 +299,7 @@ namespace Pocket.Tests
             using var parent = Log.ConfirmOnExit();
             using var child = parent.ConfirmOnExit();
             using var grandchild = child.ConfirmOnExit();
-            
+
             child.Id.Should().StartWith(parent.Id);
             grandchild.Id.Should().StartWith(parent.Id);
         }
@@ -315,7 +315,7 @@ namespace Pocket.Tests
                 for (var index = 0; index < 3; index++)
                 {
                     using var child = parent.ConfirmOnExit();
-                    
+
                     child.Fail();
                 }
 
@@ -334,7 +334,7 @@ namespace Pocket.Tests
             var log = new List<string>();
 
             using (Subscribe(e => log.Add(e.ToLogString())))
-            using (new ConfirmationLogger(message: "hello!", logOnStart: true))
+            using (new ConfirmationLogger(operationName: "Test", message: "hello!", logOnStart: true))
             {
             }
 
@@ -347,7 +347,7 @@ namespace Pocket.Tests
             var log = new List<string>();
 
             using (Subscribe(e => log.Add(e.ToLogString())))
-            using (new ConfirmationLogger(message: "{one} and {two} and {three}", logOnStart: true, args: new object[] {1, 2, 3}))
+            using (new ConfirmationLogger(operationName: "Test", message: "{one} and {two} and {three}", logOnStart: true, args: new object[] { 1, 2, 3 }))
             {
             }
 

--- a/Pocket.Logger/Tests/OperationLoggerTests.cs
+++ b/Pocket.Logger/Tests/OperationLoggerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 using static Pocket.LogEvents;
@@ -320,7 +320,7 @@ namespace Pocket.Tests
             var log = new LogEntryList();
 
             using (Subscribe(log.Add))
-            using (Log.OnEnterAndExit(exitArgs: () => new(string, object)[]
+            using (Log.OnEnterAndExit(exitArgs: () => new (string, object)[]
             {
                 ("hello", 123)
             }))
@@ -340,7 +340,7 @@ namespace Pocket.Tests
             var log = new LogEntryList();
 
             using (Subscribe(log.Add))
-            using (Log.OnExit(exitArgs: () => new(string, object)[]
+            using (Log.OnExit(exitArgs: () => new (string, object)[]
             {
                 ("hello", 123)
             }))
@@ -360,7 +360,7 @@ namespace Pocket.Tests
             var log = new List<string>();
 
             using (Subscribe(e => log.Add(e.ToLogString())))
-            using (Log.OnExit(exitArgs: () => new(string, object)[]
+            using (Log.OnExit(exitArgs: () => new (string, object)[]
             {
                 ("hello", 12345)
             }))
@@ -381,7 +381,7 @@ namespace Pocket.Tests
             var log = new List<string>();
 
             using (Subscribe(e => log.Add(e.ToLogString())))
-            using (new OperationLogger(message: "hello!", logOnStart: true))
+            using (new OperationLogger(operationName: "Test", message: "hello!", logOnStart: true))
             {
             }
 
@@ -394,7 +394,7 @@ namespace Pocket.Tests
             var log = new List<string>();
 
             using (Subscribe(e => log.Add(e.ToLogString())))
-            using (new OperationLogger(message: "{one} and {two} and {three}", logOnStart: true, args: new object[] { 1, 2, 3 }))
+            using (new OperationLogger(operationName: "Test", message: "{one} and {two} and {three}", logOnStart: true, args: new object[] { 1, 2, 3 }))
             {
             }
 


### PR DESCRIPTION
Underlying System.Diagnostics.Activity constructor throws a (mostly benign) first-chance ArgumentException (that is handled immediately) when it is passed a null operation name. See https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L445

This commit prevents this exception and makes it impossible to encounter it in the debugger (when first-chance exceptions are tuned on).