### PR TITLE
make message arg in logging methods more consistent

### DIFF
--- a/Example.Instrumented.Library/Example.Instrumented.Library.csproj
+++ b/Example.Instrumented.Library/Example.Instrumented.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+
 using LogEvent = (
     string MessageTemplate,
     object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
@@ -187,9 +188,10 @@ internal static class LoggerExtensions
 
     public static TLogger Warning<TLogger>(
             this TLogger logger,
+            string message,
             params object[]? args)
             where TLogger : Logger =>
-        logger.Warning(message: null, exception: null, args);
+        logger.Warning(message: message, exception: null, args);
 
     public static TLogger Error<TLogger>(
         this TLogger logger,
@@ -215,9 +217,10 @@ internal static class LoggerExtensions
 
     public static TLogger Error<TLogger>(
             this TLogger logger,
+            string message,
             params object[] args)
             where TLogger : Logger =>
-        logger.Error(message: "", exception: null, args);
+        logger.Error(message: message, exception: null, args);
 
     public static OperationLogger OnEnterAndExit(
         this Logger logger,
@@ -225,19 +228,21 @@ internal static class LoggerExtensions
         Func<(string name, object value)[]>? exitArgs = null,
         object? arg = null) =>
             logger.OnEnterAndExit(
-                name,
-                exitArgs,
-                arg is null ? null : [arg]);
+                message: null,
+                name: name,
+                exitArgs: exitArgs,
+                args: arg is null ? null : [arg]);
 
     public static OperationLogger OnEnterAndExit(
         this Logger logger,
+        string? message = null,
         [CallerMemberName] string? name = null,
         Func<(string name, object value)[]>? exitArgs = null,
         params object[]? args) =>
         new(
             name ?? "",
             logger.Category,
-            message: null,
+            message: message,
             exitArgs,
             logOnStart: true,
             args);
@@ -248,19 +253,21 @@ internal static class LoggerExtensions
         Func<(string name, object value)[]>? exitArgs = null,
         object? arg = null) =>
             logger.OnExit(
-                name,
-                exitArgs,
-                arg is null ? null : [arg]);
+                message: null,
+                name: name,
+                exitArgs: exitArgs,
+                args: arg is null ? null : [arg]);
 
     public static OperationLogger OnExit(
         this Logger logger,
+        string? message = null,
         [CallerMemberName] string? name = null,
         Func<(string name, object value)[]>? exitArgs = null,
         params object[]? args) =>
         new(
             name ?? "",
             logger.Category,
-            message: null,
+            message: message,
             exitArgs,
             args: args);
 
@@ -270,19 +277,21 @@ internal static class LoggerExtensions
         Func<(string name, object value)[]>? exitArgs = null,
         object? arg = null) =>
             logger.ConfirmOnExit(
-                name,
-                exitArgs,
-                arg is null ? null : [arg]);
+                message: null,
+                name: name,
+                exitArgs: exitArgs,
+                args: arg is null ? null : [arg]);
 
     public static ConfirmationLogger ConfirmOnExit(
         this Logger logger,
+        string? message = null,
         [CallerMemberName] string? name = null,
         Func<(string name, object value)[]>? exitArgs = null,
         params object[]? args) =>
         new(
             name ?? "",
             logger.Category,
-            message: null,
+            message: message,
             exitArgs,
             args: args);
 
@@ -292,19 +301,21 @@ internal static class LoggerExtensions
         Func<(string name, object value)[]>? exitArgs = null,
         object? arg = null) =>
             logger.OnEnterAndConfirmOnExit(
+                message: null, 
                 name,
                 exitArgs,
                 arg is null ? null : [arg]);
 
     public static ConfirmationLogger OnEnterAndConfirmOnExit(
         this Logger logger,
+        string? message = null,
         [CallerMemberName] string? name = null,
         Func<(string name, object value)[]>? exitArgs = null,
         params object[]? args) =>
         new(
             name ?? "",
             logger.Category,
-            message: null,
+            message: message,
             exitArgs,
             logOnStart: true,
             args);

--- a/Pocket.Logger/For.ApplicationInsights/Tests/FakeTelemetryChannel.cs
+++ b/Pocket.Logger/For.ApplicationInsights/Tests/FakeTelemetryChannel.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.ApplicationInsights.Channel;
 
+#nullable enable
+
 namespace Pocket.For.ApplicationInsights.Tests;
 
 public class FakeTelemetryChannel : ITelemetryChannel
@@ -21,5 +23,5 @@ public class FakeTelemetryChannel : ITelemetryChannel
 
     public bool? DeveloperMode { get; set; }
 
-    public string EndpointAddress { get; set; }
+    public string? EndpointAddress { get; set; }
 }

--- a/Pocket.Logger/Pocket.Logger.csproj
+++ b/Pocket.Logger/Pocket.Logger.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Pocket</RootNamespace>
-    <LangVersion>12</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="TestResults\**" />
@@ -11,18 +11,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Pocket.TypeDiscovery" Version="0.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.6" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger</id>
     <title>PocketLogger</title>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -347,10 +347,40 @@ public class ConfirmationLoggerTests : IDisposable
         var log = new List<string>();
 
         using (Subscribe(e => log.Add(e.ToLogString())))
-        using (new ConfirmationLogger(operationName: "Test", message: "{one} and {two} and {three}", logOnStart: true, args: new object[] { 1, 2, 3 }))
+        using (new ConfirmationLogger(operationName: "Test", message: "{one} and {two} and {three}", logOnStart: true, args: [1, 2, 3]))
         {
         }
 
         log.First().Should().Contain("1 and 2 and 3");
+    }
+
+    [Theory]
+    [InlineData(nameof(LoggerExtensions.OnEnterAndExit))]
+    [InlineData(nameof(LoggerExtensions.OnEnterAndConfirmOnExit))]
+    public void Using_custom_message_arg_still_provides_expected_context(string method)
+    {
+        var log = new LogEntryList();
+
+        using (Subscribe(log.Add))
+        {
+            switch (method)
+            {
+                case nameof(LoggerExtensions.OnEnterAndExit):
+                    Log.OnEnterAndExit("Hello {world}!", args: ["world"]).Dispose();
+                    break;
+                case nameof(LoggerExtensions.OnEnterAndConfirmOnExit):
+                    Log.OnEnterAndConfirmOnExit("Hello {world}!", args: ["world"]).Dispose();
+                    break;
+            }
+        }
+
+        var firstMessage = log.First().ToLogString();
+
+        firstMessage
+            .Should()
+            .Contain(nameof(Using_custom_message_arg_still_provides_expected_context));
+        firstMessage
+            .Should()
+            .Contain("▶ Hello world!");
     }
 }

--- a/Pocket.Logger/Tests/LoggerTests.cs
+++ b/Pocket.Logger/Tests/LoggerTests.cs
@@ -65,16 +65,37 @@ public class LoggerTests : IDisposable
            .BeEmpty();
     }
 
-    [Fact]
-    public void When_args_are_logged_then_they_are_templated_into_the_message()
+    [Theory]
+    [InlineData(nameof(LoggerExtensions.Info))]
+    [InlineData(nameof(LoggerExtensions.Trace))]
+    [InlineData(nameof(LoggerExtensions.Warning))]
+    [InlineData(nameof(LoggerExtensions.Error))]
+    public void When_args_are_logged_then_they_are_templated_into_the_message(string level)
     {
         var log = new LogEntryList();
 
         using (Subscribe(log.Add))
         {
-            Log.Info("It's {time} and all is {how}",
-                     DateTimeOffset.Parse("12/12/2012 12:00am"),
-                     "well");
+            switch (level)
+            {
+                case nameof(LoggerExtensions.Info):
+                    Log.Info(message: "It's {time} and all is {how}",
+                             args: [DateTimeOffset.Parse("12/12/2012 12:00am"), "well"]);
+
+                    break;
+                case nameof(LoggerExtensions.Trace):
+                    Log.Trace(message: "It's {time} and all is {how}",
+                              args: [DateTimeOffset.Parse("12/12/2012 12:00am"), "well"]);
+                    break;
+                case nameof(LoggerExtensions.Warning):
+                    Log.Warning(message: "It's {time} and all is {how}",
+                                args: [DateTimeOffset.Parse("12/12/2012 12:00am"), "well"]);
+                    break;
+                case nameof(LoggerExtensions.Error):
+                    Log.Error(message: "It's {time} and all is {how}",
+                              args: [DateTimeOffset.Parse("12/12/2012 12:00am"), "well"]);
+                    break;
+            }
         }
 
         log.Single()
@@ -82,6 +103,41 @@ public class LoggerTests : IDisposable
            .Message
            .Should()
            .Match("*It's 12/12/*12 12:00:00 AM * and all is well*");
+    }
+
+    [Theory]
+    [InlineData(nameof(LoggerExtensions.Info))]
+    [InlineData(nameof(LoggerExtensions.Trace))]
+    [InlineData(nameof(LoggerExtensions.Warning))]
+    [InlineData(nameof(LoggerExtensions.Error))]
+    public void When_string_template_and_one_arg_are_passed_then_correct_overload_is_chosen(string level)
+    {
+        var log = new LogEntryList();
+
+        using (Subscribe(log.Add))
+        {
+            switch (level)
+            {
+                case nameof(LoggerExtensions.Info):
+                    Log.Info("Hello {what}!", "world");
+                    break;
+                case nameof(LoggerExtensions.Trace):
+                    Log.Trace("Hello {what}!", "world");
+                    break;
+                case nameof(LoggerExtensions.Warning):
+                    Log.Warning("Hello {what}!", "world");
+                    break;
+                case nameof(LoggerExtensions.Error):
+                    Log.Error("Hello {what}!", "world");
+                    break;
+            }
+        }
+
+        log.Single()
+           .Evaluate()
+           .Message
+           .Should()
+           .Match("Hello world!");
     }
 
     [Fact]
@@ -326,7 +382,7 @@ public class LoggerTests : IDisposable
 
         using (Subscribe(log.Add))
         {
-            Log.Warning(new MyObject(1), new MyObject(2));
+            Log.Warning(args: new[] { new MyObject(1), new MyObject(2) });
         }
 
         log.Single().LogLevel.Should().Be((int)LogLevel.Warning);
@@ -341,7 +397,7 @@ public class LoggerTests : IDisposable
 
         using (Subscribe(log.Add))
         {
-            Log.Error(new MyObject(1), new MyObject(2));
+            Log.Error(args: [new MyObject(1), new MyObject(2)]);
         }
 
         log.Single().LogLevel.Should().Be((int)LogLevel.Error);

--- a/docs/demo/demo.csproj
+++ b/docs/demo/demo.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PocketLogger" Version="0.9.0">
+    <PackageReference Include="PocketLogger" Version="0.9.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR fixes a bug in how `Log.Warning` and `Log.Error` methods handle the message argument, and makes it easier to pass a message template when calling methods that log on exit, e.g. `Log.OnExit`, `Log.OnEnterAndConfirmOnExit`, and others.