### PR TITLE
XUnit file log improvements

### DIFF
--- a/Example.Instrumented.Library/Class1.cs
+++ b/Example.Instrumented.Library/Class1.cs
@@ -5,7 +5,7 @@ namespace Example.Instrumented.Library;
 
 public class Class1
 {
-    public static void EmitSomeLogEvents(object parameter1 = null)
+    public static void EmitSomeLogEvents(object? parameter1 = null)
     {
         using var operation = Log.OnEnterAndExit();
 

--- a/Example.Instrumented.Library/Example.Instrumented.Library.csproj
+++ b/Example.Instrumented.Library/Example.Instrumented.Library.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pocket.Logger/Core/Formatter.cs
+++ b/Pocket.Logger/Core/Formatter.cs
@@ -11,7 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using LogEvent = (
     string MessageTemplate,
-    object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
+    object[]? Args, System.Collections.Generic.List<(string Name, object? Value)> Properties,
     byte LogLevel,
     System.DateTime TimestampUtc,
     System.Exception? Exception,
@@ -50,7 +50,7 @@ internal class Formatter
 
     private readonly string template;
 
-    private readonly List<Action<StringBuilder, object>> argumentFormatters = [];
+    private readonly List<Action<StringBuilder, object?>> argumentFormatters = [];
 
     private readonly List<string> tokens = [];
 
@@ -71,7 +71,7 @@ internal class Formatter
                                 ? match.Groups["format"].Captures[0].Value
                                 : null;
 
-            void Format(StringBuilder sb, object value)
+            void Format(StringBuilder sb, object? value)
             {
                 string? formattedParam = null;
 
@@ -98,8 +98,8 @@ internal class Formatter
     public IReadOnlyList<string> Tokens => tokens;
 
     public FormatterResult Format(
-        IReadOnlyList<object>? args,
-        IList<(string Name, object Value)>? knownProperties)
+        IReadOnlyList<object?>? args,
+        IList<(string Name, object? Value)>? knownProperties)
     {
         if (args is null)
         {
@@ -158,7 +158,7 @@ internal class Formatter
         return result;
     }
 
-    public FormatterResult Format(params object[] args) => Format(args, null);
+    public FormatterResult Format(params object?[]? args) => Format(args, null);
 
     public static int CacheCount => cacheCount;
 
@@ -181,7 +181,7 @@ internal class Formatter
         }
     }
 
-    internal class FormatterResult : IReadOnlyList<(string Name, object Value)>
+    internal class FormatterResult : IReadOnlyList<(string Name, object? Value)>
     {
         private readonly StringBuilder formattedMessage;
 
@@ -190,30 +190,30 @@ internal class Formatter
             this.formattedMessage = formattedMessage;
         }
 
-        private readonly List<(string Name, object Value)> properties = [];
+        private readonly List<(string Name, object? Value)> properties = [];
 
-        public void Add(string key, object value) => properties.Add((key, value));
+        public void Add(string key, object? value) => properties.Add((key, value));
 
-        public IEnumerator<(string Name, object Value)> GetEnumerator() => properties.GetEnumerator();
+        public IEnumerator<(string Name, object? Value)> GetEnumerator() => properties.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public int Count => properties.Count;
 
-        public (string Name, object Value) this[int index] => properties[index];
+        public (string Name, object? Value) this[int index] => properties[index];
 
-        public override string ToString() => formattedMessage?.ToString() ?? "";
+        public override string ToString() => formattedMessage.ToString();
     }
 }
 
 internal static partial class Format
 {
-    public static (string Message, (string Name, object Value)[] Properties) Evaluate(this in LogEvent e)
+    public static (string Message, (string Name, object? Value)[] Properties) Evaluate(this in LogEvent e)
     {
-        (string message, (string Name, object Value)[] Properties)? evaluated = null;
+        (string message, (string Name, object? Value)[] Properties)? evaluated = null;
 
         var message = e.MessageTemplate;
-        var properties = new List<(string Name, object Value)>();
+        var properties = new List<(string Name, object? Value)>();
 
         if (e.Args?.Length != 0 || e.Properties.Count > 0)
         {

--- a/Pocket.Logger/Core/LogEvents.cs
+++ b/Pocket.Logger/Core/LogEvents.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using LogEvent = (
     string MessageTemplate,
-    object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
+    object[]? Args, System.Collections.Generic.List<(string Name, object? Value)> Properties,
     byte LogLevel,
     System.DateTime TimestampUtc,
     System.Exception? Exception,
@@ -26,7 +26,7 @@ namespace Pocket;
 internal static partial class LogEvents
 {
     public static IDisposable Enrich(
-        Action<Action<(string Name, object Value)>> onEnrich,
+        Action<Action<(string Name, object? Value)>> onEnrich,
         params Assembly[] searchInAssemblies)
     {
         var subscription = new LoggerSubscription();

--- a/Pocket.Logger/Core/Logger.cs
+++ b/Pocket.Logger/Core/Logger.cs
@@ -8,7 +8,8 @@ using System.Runtime.CompilerServices;
 
 using LogEvent = (
     string MessageTemplate,
-    object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
+    object?[]? Args, 
+    System.Collections.Generic.List<(string Name, object? Value)> Properties,
     byte LogLevel,
     System.DateTime TimestampUtc,
     System.Exception? Exception,
@@ -32,7 +33,7 @@ internal class Logger
         Category = category ?? "";
     }
 
-    public static event Action<Action<(string Name, object Value)>>? Enrich;
+    public static event Action<Action<(string Name, object? Value)>>? Enrich;
 
     public static event Action<LogEvent>? Posted;
 
@@ -66,7 +67,7 @@ internal class Logger
         LogLevel logLevel,
         string? operationName = null,
         Exception? exception = null,
-        object[]? args = null,
+        object?[]? args = null,
         in (string Name, object Value)[]? properties = null)
     {
         var logEntry = new LogEntry(
@@ -146,7 +147,7 @@ internal static class LoggerExtensions
     public static TLogger Info<TLogger>(
         this TLogger logger,
         string message,
-        params object[] args)
+        params object?[]? args)
         where TLogger : Logger
     {
         logger.Post(
@@ -369,7 +370,7 @@ internal class LogEntry
         string? category = null,
         string? operationName = null,
         OperationLogger? operation = null,
-        object[]? args = null)
+        object?[]? args = null)
     {
         LogLevel = logLevel;
         Exception = exception;
@@ -427,11 +428,11 @@ internal class LogEntry
 
     public string MessageTemplate { get; }
 
-    public List<(string Name, object Value)> Properties { get; set; } = [];
+    public List<(string Name, object? Value)> Properties { get; set; } = [];
 
-    public object[]? Args { get; set; }
+    public object?[]? Args { get; set; }
 
-    public void AddProperty((string name, object value) property) =>
+    public void AddProperty((string name, object? value) property) =>
         Properties.Add(property);
 }
 

--- a/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
+++ b/Pocket.Logger/For.ApplicationInsights/ApplicationInsightsExtensions.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -12,7 +11,7 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Metric = (string Name, double Value);
 using LogEvent = (
     string MessageTemplate,
-    object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
+    object[]? Args, System.Collections.Generic.List<(string Name, object? Value)> Properties,
     byte LogLevel,
     System.DateTime TimestampUtc,
     System.Exception? Exception,
@@ -69,7 +68,7 @@ internal static class ApplicationInsightsExtensions
         }
     }
 
-    private static void AddProperties(this ISupportProperties telemetry, in (string Name, object Value)[] properties)
+    private static void AddProperties(this ISupportProperties telemetry, in (string Name, object? Value)[] properties)
     {
         for (var i = 0; i < properties.Length; i++)
         {

--- a/Pocket.Logger/For.Xunit/FileLog.cs
+++ b/Pocket.Logger/For.Xunit/FileLog.cs
@@ -3,14 +3,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
+using LogEvent = (string MessageTemplate, object[]? Args, System.Collections.Generic.List<(string Name, object? Value)> Properties, byte LogLevel, System.DateTime TimestampUtc, System.Exception? Exception, string? OperationName, string? Category, (string? Id, bool IsStart, bool IsEnd, bool? IsSuccessful, System.TimeSpan? Duration) Operation);
 
 namespace Pocket.For.Xunit;
 
-internal class FileLog
+internal class FileLog : IDisposable
 {
     private readonly CompositeDisposable _disposables = new();
 
-    private static readonly object _lockObj = new();
+    private static readonly Lock _lockObj = new();
 
     public FileLog(string filename)
     {
@@ -18,19 +21,9 @@ internal class FileLog
         SubscribeFileLog();
     }
 
-    private void SubscribeFileLog()
-    {
-        _disposables.Add(
-            LogEvents.Subscribe(e =>
-            {
-                var entry = e.ToLogString() + Environment.NewLine;
+    public void Dispose() => _disposables.Dispose();
 
-                lock (_lockObj)
-                {
-                    System.IO.File.AppendAllText(File.FullName, entry);
-                }
-            }));
-    }
+    private void SubscribeFileLog() => _disposables.Add(LogEvents.Subscribe(WriteLogEntry));
 
     public FileInfo File { get; }
 
@@ -43,6 +36,18 @@ internal class FileLog
                 using var streamReader = new StreamReader(File.OpenRead());
                 return streamReader.ReadToEnd().Trim().Split(['\n', '\r']);
             }
+        }
+    }
+
+    public void Subscribe(Assembly[] assemblies) => _disposables.Add(LogEvents.Subscribe(WriteLogEntry,assemblies));
+
+    private void WriteLogEntry(LogEvent e)
+    {
+        var entry = e.ToLogString() + Environment.NewLine;
+
+        lock (_lockObj)
+        {
+            System.IO.File.AppendAllText(File.FullName, entry);
         }
     }
 }

--- a/Pocket.Logger/For.Xunit/LogToPocketLoggerAttribute.cs
+++ b/Pocket.Logger/For.Xunit/LogToPocketLoggerAttribute.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Xunit.Sdk;
@@ -13,8 +14,10 @@ internal class LogToPocketLoggerAttribute : BeforeAfterTestAttribute
     private bool _writeToFile;
     private string? _fileName;
     private string? _fileNameEnvironmentVariable;
+    private Type[]? _subscribeAssembliesContainingTypes;
+    private Assembly[]? _subscribeAssemblies;
 
-    private static readonly ConcurrentDictionary<MethodInfo, OperationLogger> _operations = new();
+    private static readonly ConcurrentDictionary<MethodInfo, (OperationLogger operation, FileLog? fileLog)> _operations = new();
     private static readonly AsyncLocal<FileLog> _currentFileLog = new();
     private static readonly AsyncLocal<OperationLogger> _currentOperation = new();
 
@@ -49,6 +52,20 @@ internal class LogToPocketLoggerAttribute : BeforeAfterTestAttribute
         }
     }
 
+    public Type[]? SubscribeAssembliesContainingTypes
+    {
+        get => _subscribeAssembliesContainingTypes;
+        set
+        {
+            _subscribeAssembliesContainingTypes = value;
+
+            if (value is not null)
+            {
+                _subscribeAssemblies = [..value.Select(t => t.Assembly).Distinct()];
+            }
+        }
+    }
+
     public string? FileNameEnvironmentVariable
     {
         get => _fileNameEnvironmentVariable;
@@ -76,6 +93,12 @@ internal class LogToPocketLoggerAttribute : BeforeAfterTestAttribute
         if (_writeToFile)
         {
             var testLog = new FileLog(FileName ?? $"{operationName}-{DateTime.Now:yyyy-MM-dd-hh-mm-ss}.log");
+
+            if (_subscribeAssemblies is {} assemblies)
+            {
+                testLog.Subscribe(assemblies);
+            }
+
             CurrentFileLog = testLog;
         }
 
@@ -83,19 +106,21 @@ internal class LogToPocketLoggerAttribute : BeforeAfterTestAttribute
 
         _operations.TryAdd(
             methodUnderTest,
-            operation);
+            (operation, CurrentFileLog));
     }
 
     public override void After(MethodInfo methodUnderTest)
     {
-        if (_operations.TryRemove(methodUnderTest, out var operation))
+        if (_operations.TryRemove(methodUnderTest, out var tuple))
         {
+            var (operation, fileLog) = tuple;
             operation.Dispose();
+            fileLog?.Dispose();
 
             if (CurrentOperation == operation)
             {
-                CurrentFileLog = default;
-                CurrentOperation = default;
+                CurrentFileLog = null;
+                CurrentOperation = null;
             }
         }
 

--- a/Pocket.Logger/For.Xunit/Tests/FileLogs.cs
+++ b/Pocket.Logger/For.Xunit/Tests/FileLogs.cs
@@ -6,6 +6,8 @@ using FluentAssertions;
 using Xunit;
 using static Pocket.Logger<Pocket.For.Xunit.Tests.FileLogs>;
 
+#nullable disable
+
 namespace Pocket.For.Xunit.Tests;
 
 public class FileLogs
@@ -35,7 +37,7 @@ public class FileLogs
 
         attribute.Before(methodInfo);
 
-        var file = LogToPocketLoggerAttribute.CurrentFileLog.File;
+        var file = LogToPocketLoggerAttribute.CurrentFileLog!.File;
         var message = "hello from " + methodInfo.Name + $" ({Guid.NewGuid()})";
 
         Log.Info(message);

--- a/Pocket.Logger/For.Xunit/Tests/HowAreLogsAccessed.cs
+++ b/Pocket.Logger/For.Xunit/Tests/HowAreLogsAccessed.cs
@@ -11,7 +11,7 @@ public class HowAreLogsAccessed
     {
         Logger.Log.Info("hi!");
 
-        LogToPocketLoggerAttribute.CurrentFileLog
+        LogToPocketLoggerAttribute.CurrentFileLog?
                .Lines
                .Should()
                .Contain(line => line.Contains("hi!"));

--- a/Pocket.Logger/For.Xunit/Tests/PerTestSubscriptionsAreDisposed.cs
+++ b/Pocket.Logger/For.Xunit/Tests/PerTestSubscriptionsAreDisposed.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pocket.For.Xunit.Tests;
+
+[LogToPocketLogger(FileNameEnvironmentVariable = $"{nameof(PerTestSubscriptionsAreDisposed)}_LOG_FILE")]
+public class PerTestSubscriptionsAreDisposed(ITestOutputHelper output)
+{
+    private FileInfo? _logFile;
+
+    static PerTestSubscriptionsAreDisposed()
+    {
+        Environment.SetEnvironmentVariable(
+            $"{nameof(PerTestSubscriptionsAreDisposed)}_LOG_FILE",
+            $"{nameof(PerTestSubscriptionsAreDisposed)}-{DateTime.Now:yyyy-MM-dd-hh-mm-ss}.log");
+    }
+
+    private async Task AssertSingleOccurrenceOfStringInLogFile([CallerMemberName] string? methodName = null)
+    {
+        _logFile = LogToPocketLoggerAttribute.CurrentFileLog?.File;
+
+        if (_logFile is not null)
+        {
+            output.WriteLine($"Log file is: {_logFile.FullName}");
+
+            await Task.Delay(20);
+
+            var text = await File.ReadAllTextAsync(_logFile.FullName);
+
+            if (methodName is not null &&
+                CountSubstring(text, $"{methodName}]  ▶") > 1)
+            {
+                throw new AssertionFailedException(
+                    $"""
+                     {methodName} was logged more than once:
+
+                     {text}
+                     """);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task test1()
+    {
+        await AssertSingleOccurrenceOfStringInLogFile();
+    }
+
+    [Fact]
+    public async Task test2()
+    {
+        await AssertSingleOccurrenceOfStringInLogFile();
+    }
+
+    [Fact]
+    public async Task test3()
+    {
+        await AssertSingleOccurrenceOfStringInLogFile();
+    }
+
+    [Fact]
+    public async Task test4()
+    {
+        await AssertSingleOccurrenceOfStringInLogFile();
+    }
+
+    private int CountSubstring(string text, string substring)
+    {
+        int count = 0;
+        int index = 0;
+
+        while ((index = text.IndexOf(substring, index, StringComparison.OrdinalIgnoreCase)) != -1)
+        {
+            count++;
+            index += substring.Length;
+        }
+
+        return count;
+    }
+}

--- a/Pocket.Logger/For.Xunit/Tests/WhatIsLogged.cs
+++ b/Pocket.Logger/For.Xunit/Tests/WhatIsLogged.cs
@@ -1,5 +1,6 @@
-﻿using FluentAssertions;
-using System.Linq;
+﻿using System.Linq;
+using Example.Instrumented.Library;
+using FluentAssertions;
 using Xunit;
 
 namespace Pocket.For.Xunit.Tests;
@@ -41,5 +42,28 @@ public class WhatIsLogged
            .Last()
            .Should()
            .Match($"*[🧪:{GetType().Name}.{nameof(Stop_events_are_logged_for_each_test)}]  ⏹ (*ms)*");
+    }
+
+    [Fact]
+    public void Events_from_called_assemblies_can_be_logged()
+    {
+        var attribute = new LogToPocketLoggerAttribute(true)
+        {
+            SubscribeAssembliesContainingTypes = [ typeof(Class1) ]
+        };
+
+        var methodInfo = GetType().GetMethod(nameof(Stop_events_are_logged_for_each_test))!;
+
+        attribute.Before(methodInfo);
+
+        var log = LogToPocketLoggerAttribute.CurrentFileLog!;
+
+        Class1.EmitSomeLogEvents("hello");
+
+        attribute.After(methodInfo);
+
+        log.Lines
+           .Should()
+           .Contain(line => line.Contains("hello"));
     }
 }

--- a/Pocket.Logger/For.Xunit/Tests/WhatIsLogged.cs
+++ b/Pocket.Logger/For.Xunit/Tests/WhatIsLogged.cs
@@ -11,11 +11,11 @@ public class WhatIsLogged
     {
         var attribute = new LogToPocketLoggerAttribute(true);
 
-        var methodInfo = GetType().GetMethod(nameof(Start_events_are_logged_for_each_test));
+        var methodInfo = GetType().GetMethod(nameof(Start_events_are_logged_for_each_test))!;
 
         attribute.Before(methodInfo);
 
-        var log = LogToPocketLoggerAttribute.CurrentFileLog.Lines;
+        var log = LogToPocketLoggerAttribute.CurrentFileLog!.Lines;
 
         attribute.After(methodInfo);
 
@@ -29,11 +29,11 @@ public class WhatIsLogged
     {
         var attribute = new LogToPocketLoggerAttribute(true);
 
-        var methodInfo = GetType().GetMethod(nameof(Stop_events_are_logged_for_each_test));
+        var methodInfo = GetType().GetMethod(nameof(Stop_events_are_logged_for_each_test))!;
 
         attribute.Before(methodInfo);
 
-        var log = LogToPocketLoggerAttribute.CurrentFileLog;
+        var log = LogToPocketLoggerAttribute.CurrentFileLog!;
 
         attribute.After(methodInfo);
 

--- a/Pocket.Logger/Pocket.Logger.csproj
+++ b/Pocket.Logger/Pocket.Logger.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Pocket</RootNamespace>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/Pocket.Logger/Pocket.Logger.csproj
+++ b/Pocket.Logger/Pocket.Logger.csproj
@@ -14,19 +14,17 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Pocket.TypeDiscovery" Version="0.6.0">
+    <PackageReference Include="Pocket.TypeDiscovery" Version="0.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.6" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Pocket.Logger/PocketLogger.For.ApplicationInsights.nuspec
+++ b/Pocket.Logger/PocketLogger.For.ApplicationInsights.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.For.ApplicationInsights</id>
     <title>PocketLogger.For.ApplicationInsights</title>
-    <version>0.9.0</version>
+    <version>0.11.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -13,9 +13,9 @@
     <license type="expression">MIT</license>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="PocketLogger" version="[0.9.0,)" include="all" />
-      <dependency id="PocketLogger.Subscribe" version="[0.9.0,)" include="all" />
-      <dependency id="Microsoft.ApplicationInsights" version="[2.22.0,)" />
+      <dependency id="PocketLogger" version="[0.11.0,)" include="all" />
+      <dependency id="PocketLogger.Subscribe" version="[0.11.0,)" include="all" />
+      <dependency id="Microsoft.ApplicationInsights" version="[2.23.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/Pocket.Logger/PocketLogger.For.MicrosoftExtensionsLogging.nuspec
+++ b/Pocket.Logger/PocketLogger.For.MicrosoftExtensionsLogging.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.For.MicrosoftExtensionsLogging</id>
     <title>PocketLogger.For.MicrosoftExtensionsLogging</title>
-    <version>0.8.0</version>
+    <version>0.9.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -13,8 +13,8 @@
     <license type="expression">MIT</license>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="PocketLogger" version="[0.8.0,)" include="all" />
-      <dependency id="Microsoft.Extensions.Logging" version="[7.0.0,)" />
+      <dependency id="PocketLogger" version="[0.11.0,)" include="all" />
+      <dependency id="Microsoft.Extensions.Logging" version="[9.0.0,)" />
     </dependencies>
   </metadata>
   <files>

--- a/Pocket.Logger/PocketLogger.For.Xunit.nuspec
+++ b/Pocket.Logger/PocketLogger.For.Xunit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.For.Xunit</id>
     <title>PocketLogger.For.Xunit</title>
-    <version>0.11.0</version>
+    <version>0.11.1</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/PocketLogger.For.Xunit.nuspec
+++ b/Pocket.Logger/PocketLogger.For.Xunit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.For.Xunit</id>
     <title>PocketLogger.For.Xunit</title>
-    <version>0.9.0</version>
+    <version>0.11.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -13,8 +13,8 @@
     <license type="expression">MIT</license>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="PocketLogger" version="[0.9.0,)" include="all" />
-      <dependency id="PocketLogger.Subscribe" version="[0.9.0,)" include="all" />
+      <dependency id="PocketLogger" version="[0.11.0,)" include="all" />
+      <dependency id="PocketLogger.Subscribe" version="[0.11.0,)" include="all" />
       <dependency id="xunit" version="[2.7.0,)" />
     </dependencies>
   </metadata>

--- a/Pocket.Logger/PocketLogger.Subscribe.nuspec
+++ b/Pocket.Logger/PocketLogger.Subscribe.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger.Subscribe</id>
     <title>PocketLogger.Subscribe</title>
-    <version>0.9.0</version>
+    <version>0.11.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>
@@ -20,7 +20,7 @@ The PocketLogger.Subscribe package enables subscribing to the log events emitted
     <license type="expression">MIT</license>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="PocketLogger" version="[0.9.0,)" include="all" />
+      <dependency id="PocketLogger" version="[0.11.0,)" include="all" />
       <dependency id="Pocket.Disposable" version="[1.2.0,)" include="all" />
       <dependency id="Pocket.TypeDiscovery" version="[0.6.0,)" include="all" />
     </dependencies>

--- a/Pocket.Logger/PocketLogger.nuspec
+++ b/Pocket.Logger/PocketLogger.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketLogger</id>
     <title>PocketLogger</title>
-    <version>0.10.0</version>
+    <version>0.11.0</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketlogger</projectUrl>

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -143,7 +143,7 @@ public class ConfirmationLoggerTests : IDisposable
            .Properties
            .Select(_ => _.Value)
            .Should()
-           .ContainSingle(arg => arg.Equals("bye!"));
+           .ContainSingle(arg => arg!.Equals("bye!"));
     }
 
     [Fact]
@@ -162,9 +162,9 @@ public class ConfirmationLoggerTests : IDisposable
                             .Properties;
 
         properties
-            .Select(_ => _.Value)
+            .Select(p => p.Value)
             .Should()
-            .ContainSingle(arg => arg.Equals("bye!"));
+            .ContainSingle(arg => arg!.Equals("bye!"));
     }
 
     [Fact]
@@ -198,7 +198,7 @@ public class ConfirmationLoggerTests : IDisposable
         var infoEvent = log
                         .Single(e => e.Evaluate().Message == "hello")
                         .Operation
-                        .Duration
+                        .Duration!
                         .Value;
 
         infoEvent.Should()
@@ -237,7 +237,7 @@ public class ConfirmationLoggerTests : IDisposable
            .Evaluate()
            .Properties
            .Should()
-           .Contain(p => p.Name == "hello" && p.Value.Equals(123));
+           .Contain(p => p.Name == "hello" && p.Value!.Equals(123));
     }
 
     [Fact]
@@ -325,7 +325,7 @@ public class ConfirmationLoggerTests : IDisposable
         var results = log.Select(l => l.Operation.IsSuccessful);
 
         results.Should().BeEquivalentTo(
-            new object[] { null, false, false, false, true });
+            new object?[] { null, false, false, false, true });
     }
 
     [Fact]

--- a/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
+++ b/Pocket.Logger/Tests/ConfirmationLoggerTests.cs
@@ -226,10 +226,7 @@ public class ConfirmationLoggerTests : IDisposable
         var log = new LogEntryList();
 
         using (Subscribe(log.Add))
-        using (Log.ConfirmOnExit(exitArgs: () => new (string, object)[]
-               {
-                   ("hello", 123)
-               }))
+        using (Log.ConfirmOnExit(exitArgs: () => [("hello", 123)]))
         {
         }
 
@@ -246,10 +243,7 @@ public class ConfirmationLoggerTests : IDisposable
         var log = new List<string>();
 
         using (Subscribe(e => log.Add(e.ToLogString())))
-        using (Log.ConfirmOnExit(exitArgs: () => new (string, object)[]
-               {
-                   ("hello", 12345)
-               }))
+        using (Log.ConfirmOnExit(exitArgs: () => [("hello", 12345)]))
         {
         }
 

--- a/Pocket.Logger/Tests/FormatterTests.cs
+++ b/Pocket.Logger/Tests/FormatterTests.cs
@@ -50,7 +50,7 @@ public class FormatterTests
     {
         var formatter = Formatter.Parse("The value is {value}");
 
-        var result = formatter.Format(new object[] { null });
+        var result = formatter.Format([null]);
 
         result.Single(v => v.Name == "value").Value.Should().BeNull();
     }
@@ -74,7 +74,7 @@ public class FormatterTests
     {
         var formatter = Formatter.Parse("The value is {value}");
 
-        var result = formatter.Format(new object[] { null });
+        var result = formatter.Format([null]);
 
         result.ToString()
               .Should()
@@ -147,7 +147,7 @@ public class FormatterTests
 
         var result = formatter.Format(
             args: null,
-            knownProperties: new List<(string, object)>
+            knownProperties: new List<(string, object?)>
             {
                 ("also", "this")
             });
@@ -163,8 +163,8 @@ public class FormatterTests
         var formatter = Formatter.Parse("{one} and {two}");
 
         var result = formatter.Format(
-            args: new object[] { 1, 2, 3, 4 },
-            knownProperties: new List<(string, object)>
+            args: [1, 2, 3, 4],
+            knownProperties: new List<(string, object?)>
             {
                 ("also", "this")
             });
@@ -229,10 +229,8 @@ public class FormatterTests
     {
         var entries = new List<string>();
 
-        Action<(string MessageTemplate, object[] Args, List<(string Name, object Value)> Properties, byte LogLevel, DateTime TimestampUtc, Exception Exception, string OperationName, string Category, (string Id, bool IsStart, bool IsEnd, bool? IsSuccessful, TimeSpan? Duration) Operation)> onEntryPosted = e => entries.Add(e.ToLogString());
-
         using var subscription = LogEvents.Subscribe(
-            onEntryPosted,
+            e => entries.Add(e.ToLogString()),
             typeof(Class1).Assembly);
 
         Class1.EmitSomeLogEvents("customize me:replace me with empty string");

--- a/Pocket.Logger/Tests/LogEnrichmentTests.cs
+++ b/Pocket.Logger/Tests/LogEnrichmentTests.cs
@@ -39,7 +39,7 @@ public class LogEnrichmentTests : IDisposable
                             e.Evaluate()
                              .Properties
                              .Any(p => p.Name == "enriched" &&
-                                       p.Value.Equals("hello!")));
+                                       p.Value!.Equals("hello!")));
     }
 
     [Fact]
@@ -119,12 +119,12 @@ public class LogEnrichmentTests : IDisposable
               .Properties
               .Should()
               .Contain(p => p.Name == "one" &&
-                            p.Value.Equals(1));
+                            p.Value!.Equals(1));
         log[2].Evaluate()
               .Properties
               .Should()
               .Contain(p => p.Name == "two" &&
-                            p.Value.Equals("two"));
+                            p.Value!.Equals("two"));
         log[3].Evaluate()
               .Properties
               .Select(p => p.Value)

--- a/Pocket.Logger/Tests/LogEntryList.cs
+++ b/Pocket.Logger/Tests/LogEntryList.cs
@@ -4,7 +4,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using LogEvent = (
     string MessageTemplate,
-    object[]? Args, System.Collections.Generic.List<(string Name, object Value)> Properties,
+    object[]? Args, System.Collections.Generic.List<(string Name, object? Value)> Properties,
     byte LogLevel,
     System.DateTime TimestampUtc,
     System.Exception? Exception,

--- a/Pocket.Logger/Tests/LoggerTests.cs
+++ b/Pocket.Logger/Tests/LoggerTests.cs
@@ -141,7 +141,7 @@ public class LoggerTests : IDisposable
     }
 
     [Fact]
-    public void When_args_are_logged_they_are_accessble_on_the_LogEntry()
+    public void When_args_are_logged_they_are_accessible_on_the_LogEntry()
     {
         var log = new LogEntryList();
 
@@ -156,7 +156,7 @@ public class LoggerTests : IDisposable
            .Should()
            .ContainSingle(p =>
                               p.Name.Equals("how") &&
-                              p.Value.Equals("well"));
+                              p.Value!.Equals("well"));
     }
 
     [Fact]
@@ -336,13 +336,13 @@ public class LoggerTests : IDisposable
 
     private class MyObject
     {
-        private int value;
+        private readonly int value;
 
         public MyObject(int value)
             => this.value = value;
 
         public override string ToString()
-            => $"my object {this.value}";
+            => $"my object {value}";
     }
 
     [Fact]

--- a/Pocket.Logger/Tests/OperationLoggerTests.cs
+++ b/Pocket.Logger/Tests/OperationLoggerTests.cs
@@ -216,7 +216,7 @@ public class OperationLoggerTests : IDisposable
         using (Subscribe(log.Add))
         using (var operation = Log.OnEnterAndExit())
         {
-            operationId = operation.Id;
+            operationId = operation.Id!;
 
             operation.Info("hello");
         }
@@ -237,7 +237,7 @@ public class OperationLoggerTests : IDisposable
 
         log.Last()
            .Operation
-           .Duration
+           .Duration!
            .Value
            .TotalMilliseconds
            .Should()
@@ -299,7 +299,7 @@ public class OperationLoggerTests : IDisposable
     }
 
     [Fact]
-    public void By_befault_an_operation_has_no_category()
+    public void By_default_an_operation_has_no_category()
     {
         var log = new LogEntryList();
 
@@ -331,7 +331,7 @@ public class OperationLoggerTests : IDisposable
            .Evaluate()
            .Properties
            .Should()
-           .Contain(p => p.Name == "hello" && p.Value.Equals(123));
+           .Contain(p => p.Name == "hello" && p.Value!.Equals(123));
     }
 
     [Fact]
@@ -351,7 +351,7 @@ public class OperationLoggerTests : IDisposable
            .Evaluate()
            .Properties
            .Should()
-           .Contain(p => p.Name == "hello" && p.Value.Equals(123));
+           .Contain(p => p.Name == "hello" && p.Value!.Equals(123));
     }
 
     [Fact]

--- a/docs/demo/Examples.cs
+++ b/docs/demo/Examples.cs
@@ -211,7 +211,7 @@ public class Examples
 
     public static void SubscribeAndSendToConsole()
     {
-        Program.ConsoleSubscription.Dispose();
+        Program.ConsoleSubscription?.Dispose();
 
         #region SubscribeAndSendToConsole
 
@@ -231,7 +231,7 @@ public class Examples
 
     public static void LogEventStructure()
     {
-        Program.ConsoleSubscription.Dispose();
+        Program.ConsoleSubscription?.Dispose();
 
         #region LogEventStructure
 
@@ -263,7 +263,7 @@ public class Examples
 
     public static void Evaluate()
     {
-        Program.ConsoleSubscription.Dispose();
+        Program.ConsoleSubscription?.Dispose();
 
         #region Evaluate
 
@@ -289,7 +289,7 @@ public class Examples
 
     public static void SubscribeAndSendToSerilog()
     {
-        Program.ConsoleSubscription.Dispose();
+        Program.ConsoleSubscription?.Dispose();
 
         #region SubscribeAndSendToSerilog
             
@@ -320,7 +320,7 @@ public class Examples
 
         LogEvents.Enrich(add =>
         {
-            add(("app_version", Assembly.GetExecutingAssembly().GetName().Version));
+            add(("app_version", Assembly.GetExecutingAssembly().GetName().Version!));
             add(("machine_name", Environment.MachineName));
         });
 

--- a/docs/demo/Program.cs
+++ b/docs/demo/Program.cs
@@ -7,11 +7,11 @@ namespace Demo;
 static class Program
 {
     static async Task<int> Main(
-        string session = null,
-        string region = null,
-        string project = null,
-        string package = null,
-        string[] args = null)
+        string? session = null,
+        string? region = null,
+        string? project = null,
+        string? package = null,
+        string[]? args = null)
     {
         ConsoleSubscription =
             #region LoggingToTheConsole
@@ -67,7 +67,7 @@ static class Program
         };
     }
 
-    public static LoggerSubscription ConsoleSubscription { get; private set; }
+    public static LoggerSubscription? ConsoleSubscription { get; private set; }
 
     private static int Call(Action action)
     {

--- a/docs/demo/demo.csproj
+++ b/docs/demo/demo.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-	  <NoWarn>CS1591</NoWarn>
+    <NoWarn>CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/demo/demo.csproj
+++ b/docs/demo/demo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PocketLogger" Version="0.9.1">
+    <PackageReference Include="PocketLogger" Version="0.10.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This adds support for specifying additional assemblies to participate in attribute-based test logging with `LogToPocketLoggerAttribute`. It also fixes a bug where test start and stop events are written more than once to the file log.